### PR TITLE
Able to send data

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,28 +4,27 @@
 name: Node.js CI
 
 on:
-  push:
-    branches: ["master"]
-  pull_request:
-    branches: [ "master" ]
+    push:
+        branches: ['master']
+    pull_request:
+        branches: ['master']
 
 jobs:
-  build:
+    build:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [18.x, 20.x, 22.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x, 22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm run test:unit
+        steps:
+            - uses: actions/checkout@v4
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: 'npm'
+            - run: npm ci
+            - run: npm run build --if-present
+            - run: npm run test:unit

--- a/dist/src/app.js
+++ b/dist/src/app.js
@@ -1,6 +1,6 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const encoding_1 = require("./encoding");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const encoding_1 = require('./encoding');
 const run = () => {
     console.log('DNS resolver running 👾\n');
     let tc1 = {

--- a/dist/src/encoding.js
+++ b/dist/src/encoding.js
@@ -1,8 +1,8 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
 exports.createDNSMessageBuffer = createDNSMessageBuffer;
 exports.encodeHostname = encodeHostname;
-const buffer_1 = require("buffer");
+const buffer_1 = require('buffer');
 // NOTE: Creates a message buffer to store the DNS message being sent
 // Allocates 12 bytes for the header plus the length of the question
 function createDNSMessageBuffer(message) {

--- a/dist/test/encoding.test.js
+++ b/dist/test/encoding.test.js
@@ -1,7 +1,7 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const vitest_1 = require("vitest");
-const encoding_1 = require("../src/encoding");
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const vitest_1 = require('vitest');
+const encoding_1 = require('../src/encoding');
 (0, vitest_1.describe)('encodeHostname', () => {
     (0, vitest_1.it)('should encode a hostname string correctly', () => {
         const input = 'dns.google.com';
@@ -44,16 +44,28 @@ const dnsMessageCase2 = {
     cquery: 1,
 };
 (0, vitest_1.describe)('createDNSMessageBuffer', () => {
-    (0, vitest_1.it)('should encode the dns message correctly for dns.google.com', () => {
-        const expectedHex = '00160100000100000000000003646e7306676f6f676c6503636f6d0000010001';
-        const actualBuffer = (0, encoding_1.createDNSMessageBuffer)(dnsMessageCase1);
-        const actualHex = actualBuffer.toString('hex');
-        (0, vitest_1.expect)(actualHex).toBe(expectedHex);
-    });
-    (0, vitest_1.it)('should encode the dns message correctly for example.com', () => {
-        const expectedHex = '002101000001000000000000076578616d706c6503636f6d0000010001';
-        const actualBuffer = (0, encoding_1.createDNSMessageBuffer)(dnsMessageCase2);
-        const actualHex = actualBuffer.toString('hex');
-        (0, vitest_1.expect)(actualHex).toBe(expectedHex);
-    });
+    (0, vitest_1.it)(
+        'should encode the dns message correctly for dns.google.com',
+        () => {
+            const expectedHex =
+                '00160100000100000000000003646e7306676f6f676c6503636f6d0000010001';
+            const actualBuffer = (0, encoding_1.createDNSMessageBuffer)(
+                dnsMessageCase1,
+            );
+            const actualHex = actualBuffer.toString('hex');
+            (0, vitest_1.expect)(actualHex).toBe(expectedHex);
+        },
+    );
+    (0, vitest_1.it)(
+        'should encode the dns message correctly for example.com',
+        () => {
+            const expectedHex =
+                '002101000001000000000000076578616d706c6503636f6d0000010001';
+            const actualBuffer = (0, encoding_1.createDNSMessageBuffer)(
+                dnsMessageCase2,
+            );
+            const actualHex = actualBuffer.toString('hex');
+            (0, vitest_1.expect)(actualHex).toBe(expectedHex);
+        },
+    );
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
-import { DNSMessage, encodeHostname, createDNSMessageBuffer } from "./encoding";
+import { DNSMessage, encodeHostname, createDNSMessageBuffer } from './encoding';
+import { sendDNSMessageUDP } from './udp';
 
 const run = () => {
     console.log('DNS resolver running 👾\n');
@@ -15,8 +16,9 @@ const run = () => {
         cquery: 1,
     };
 
-    let result = createDNSMessageBuffer(tc1);
-    console.log(`Result of encoded DNS message: ${result.toString('hex')}`);
+    const msg1 = createDNSMessageBuffer(tc1);
+    // console.log(`Result of encoded DNS message: ${msg1.toString('hex')}`);
+    sendDNSMessageUDP(msg1);
 };
 
 run();

--- a/src/udp.ts
+++ b/src/udp.ts
@@ -1,0 +1,29 @@
+// NOTE: Creates a UDP client to send our DNS message to a name server
+import * as dgram from 'dgram';
+
+const client = dgram.createSocket('udp4');
+
+client.on('message', (msg, info) => {
+    console.log('Data received from server : ' + msg.toString('hex'));
+    console.log(
+        'Received %d bytes from %s:%d\n',
+        msg.length,
+        info.address,
+        info.port,
+    );
+
+    client.close(() => {
+        console.log('Connection closed');
+    });
+});
+
+export function sendDNSMessageUDP(message: Buffer) {
+    client.send(message, 53, '8.8.8.8', (error) => {
+        if (error) {
+            console.log(`An error occured: ${error}`);
+            client.close();
+        } else {
+            console.log(`Sent message: ${message.toString('hex')}`);
+        }
+    });
+}

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { DNSMessage, createDNSMessageBuffer, encodeHostname } from '../src/encoding';
+import {
+    DNSMessage,
+    createDNSMessageBuffer,
+    encodeHostname,
+} from '../src/encoding';
 
 describe('encodeHostname', () => {
     it('should encode a hostname string correctly', () => {


### PR DESCRIPTION
This PR allows us to connect to a nameserver via UDP and send our DNS message to that server. For testing purposes, I used the Google DNS server via 8.8.8.8 port 53 to open the connection, send our message, receive a response, and then close the connection.

Message sent (hex): 00160100000100000000000003646e7306676f6f676c6503636f6d0000010001
Received message (hex): 00168180000100020000000003646e7306676f6f676c6503636f6d0000010001c00c000100010000008d000408080808c00c000100010000008d000408080404

Right now all we care about is that the first two bytes in both messages (which are the id) are the same. For this case, they match, 0016, or 22 in decimal